### PR TITLE
Added endpoint logic for manual token creation

### DIFF
--- a/lib/Anchor/Tokens/Server/Store.hs
+++ b/lib/Anchor/Tokens/Server/Store.hs
@@ -112,12 +112,12 @@ listTokens
     => Int
     -> UserID
     -> Page
-    -> m ([(Maybe ClientID, Scope, TokenID)], Int)
+    -> m ([(Maybe ClientID, Scope, Token, TokenID)], Int)
 listTokens size uid (Page p) = do
     pool <- ask
     withResource pool $ \conn -> do
         liftIO . debugM logName $ "Listing tokens for " <> show uid
-        tokens <- liftIO $ query conn "SELECT client_id, scope, token_id FROM tokens WHERE (user_id = ?) AND revoked is NULL LIMIT ? OFFSET ? ORDER BY created" (uid, size, (p - 1) * size)
+        tokens <- liftIO $ query conn "SELECT client_id, scope, token, token_id FROM tokens WHERE (user_id = ?) AND revoked is NULL LIMIT ? OFFSET ? ORDER BY created" (uid, size, (p - 1) * size)
         [Only numTokens] <- liftIO $ query conn "SELECT count(*) FROM tokens WHERE (user_id = ?)" (Only uid)
         return (tokens, numTokens)
 
@@ -130,12 +130,12 @@ displayToken
        )
     => UserID
     -> TokenID
-    -> m (Maybe (Maybe ClientID, Scope, TokenID))
+    -> m (Maybe (Maybe ClientID, Scope, Token, TokenID))
 displayToken user_id token_id = do
     pool <- ask
     withResource pool $ \conn -> do
         liftIO . debugM logName $ "Retrieving token with id " <> show token_id <> " for user " <> show user_id
-        tokens <- liftIO $ query conn "SELECT client_id, scope, token_id FROM tokens WHERE (token_id = ?) AND (user_id = ?) AND revoked is NULL" (token_id, user_id)
+        tokens <- liftIO $ query conn "SELECT client_id, scope, token, token_id FROM tokens WHERE (token_id = ?) AND (user_id = ?) AND revoked is NULL" (token_id, user_id)
         case tokens of
             []  -> return Nothing
             [x] -> return $ Just x

--- a/lib/Anchor/Tokens/Server/Store.hs
+++ b/lib/Anchor/Tokens/Server/Store.hs
@@ -142,6 +142,20 @@ displayToken user_id token_id = do
             xs  -> let msg = "Should only be able to retrieve at most one token, retrieved: " <> show xs
                    in liftIO (errorM logName msg) >> fail msg
 
+createToken
+    :: ( MonadIO m
+       , MonadBaseControl IO m
+       , MonadReader (Pool Connection) m
+       )
+    => UserID
+    -> Scope
+    -> m TokenID
+createToken user_id scope = do
+    pool <- ask
+    withResource pool $ \conn ->
+        --liftIO $ execute conn "INSERT INTO tokens VALUES ..."
+        error "wat"
+
 revokeToken
     :: ( MonadIO m
        , MonadBaseControl IO m

--- a/lib/Anchor/Tokens/Server/Types.hs
+++ b/lib/Anchor/Tokens/Server/Types.hs
@@ -4,8 +4,11 @@
 module Anchor.Tokens.Server.Types where
 
 import           Control.Applicative
+import           Control.Lens.Operators
+import           Control.Monad
 import           Control.Monad.Trans.Except
 import           Data.ByteString            (ByteString)
+import           Data.Maybe
 import           Data.Pool
 import           Data.Text                   (Text)
 import           Database.PostgreSQL.Simple
@@ -34,6 +37,11 @@ instance ToField TokenID where
 
 instance FromField TokenID where
     fromField f bs = TokenID <$> fromField f bs
+
+instance FromField Token where
+    fromField f bs = do
+        rawToken <- fromField f bs
+        maybe mzero return (rawToken ^? token)
 
 -- | Page number for paginated user interfaces.
 --

--- a/lib/Anchor/Tokens/Server/UI.hs
+++ b/lib/Anchor/Tokens/Server/UI.hs
@@ -11,12 +11,14 @@ import qualified Data.ByteString.Char8           as BS
 import           Data.FileEmbed
 import           Data.Maybe
 import           Data.Monoid
+import qualified Data.Set                        as S
+import qualified Data.Text.Encoding              as T
 import           Data.Text.Lazy                  (Text)
 import qualified Data.Text.Lazy                  as T
 import           Prelude                         hiding (head)
 import           Text.Blaze.Html.Renderer.Pretty
-import           Text.Blaze.Html5                hiding (div)
-import           Text.Blaze.Html5.Attributes     hiding (form, style, title)
+import           Text.Blaze.Html5                hiding (div, map)
+import           Text.Blaze.Html5.Attributes     hiding (form, scope, style, title)
 
 import           Network.OAuth2.Server.Types
 
@@ -71,9 +73,9 @@ htmlToken (cid, scope, t, tid) = tr $ do
     td htmlToken'
     td htmlRevokeButton
   where
-    htmlCid = toHtml $ BS.unpack $ maybe "None" (review clientID) cid
-    htmlScope = preEscapedToHtml $ BS.unpack $ scopeToBs scope
-    htmlToken' = preEscapedToHtml $ BS.unpack $ token # t
+    htmlCid    = toHtml $ T.decodeUtf8 $ maybe "None" (review clientID) cid
+    htmlScope  = toHtml $ T.decodeUtf8 $ scopeToBs scope
+    htmlToken' = toHtml $ T.decodeUtf8 $ token # t
     htmlRevokeButton =
         form ! method "POST" ! action ("/tokens/" <> toValue tid) $ do
             input ! type_ "hidden" ! name "method" ! value "delete"

--- a/lib/Anchor/Tokens/Server/UI.hs
+++ b/lib/Anchor/Tokens/Server/UI.hs
@@ -25,13 +25,14 @@ import           Anchor.Tokens.Server.Types
 stylesheet :: String
 stylesheet = BS.unpack $(embedFile "style.css")
 
-renderTokensPage :: Int -> Page -> ([(Maybe ClientID, Scope, Token, TokenID)], Int) -> Html
-renderTokensPage size (Page p) (ts, numTokens) = docTypeHtml $ do
+renderTokensPage :: Scope -> Int -> Page -> ([(Maybe ClientID, Scope, Token, TokenID)], Int) -> Html
+renderTokensPage userScope size (Page p) (ts, numTokens) = docTypeHtml $ do
     head $ do
         title "Such Token"
         style ! type_ "text/css" $ toHtml stylesheet
     body $
         if validPage then do
+            htmlCreateTokenForm userScope
             htmlTokens ts
             when prevPages htmlPrevPageButton
             when nextPages htmlNextPageButton
@@ -48,6 +49,9 @@ renderTokensPage size (Page p) (ts, numTokens) = docTypeHtml $ do
     htmlPrevPageButton = htmlPageButton (p-1)
     htmlNextPageButton = htmlPageButton (p+1)
     htmlInvalidPage = h2 "Invalid page number!"
+
+htmlCreateTokenForm :: Scope -> Html
+htmlCreateTokenForm s = return ()
 
 htmlTokens :: [(Maybe ClientID, Scope, Token, TokenID)] -> Html
 htmlTokens [] = h2 "You have no tokens!"


### PR DESCRIPTION
Changed logic of delete post to use a parameter instead of a capture.
Added link to first page of tokens at top of each page.
Display actual tokens in each table.
Added create logic+form to UI.
Some consolidation of shibboleth header handling.
Made bytestring to html conversion consistently utf-8.