### PR TITLE
Replace MonadBaseControl instance for use in store

### DIFF
--- a/lib/Anchor/Tokens/Server/Store.hs
+++ b/lib/Anchor/Tokens/Server/Store.hs
@@ -299,8 +299,8 @@ instance MonadTransControl Store where
 
 deriving instance MonadBase b m => MonadBase b (Store m)
 
-instance MonadBaseControl IO (Store IO) where
-  type StM (Store IO) a  = ComposeSt Store IO a
+instance MonadBaseControl b m => MonadBaseControl b (Store m) where
+  type StM (Store m) a = ComposeSt Store m a
   liftBaseWith = defaultLiftBaseWith
   restoreM     = defaultRestoreM
 


### PR DESCRIPTION
Replace the MonadBaseControl IO instance in the store with one that which will actually work for us.