### PR TITLE
runit: stop using PG user and pass

### DIFF
--- a/examples/anchor-token-server.conf
+++ b/examples/anchor-token-server.conf
@@ -1,5 +1,5 @@
 log-level = "DEBUG"
-database = "dbname=DBNAME user=DBUSER password=DBPASS"
+database = "dbname=DBNAME"
 
 stats {
     host = "localhost"

--- a/runit.sh
+++ b/runit.sh
@@ -5,8 +5,6 @@
 # These values MUST NOT contain meta characters (for shell, SQL, or regular
 # expressions).
 DBNAME="token_server_test"
-DBUSER="token_server_test"
-DBPASS="password"
 DBDESC="Transient database for token server testing"
 
 TESTCONF="/tmp/anchor-token-server-$$.conf"
@@ -15,27 +13,14 @@ cd $(dirname $0)
 
 # Clean up our mess from last time
 dropdb --if-exists $DBNAME
-dropuser --if-exists $DBUSER
 
-# Create some mess
-psql <<EOQ
-CREATE USER $DBUSER WITH
-    LOGIN
-    PASSWORD '$DBPASS'
-;
-CREATE DATABASE $DBNAME WITH
-    OWNER = $DBUSER
-    ENCODING = 'UTF-8'
-;
-EOQ
+createdb $DBNAME "$DBDESC"
 
-export PGPASSWORD=$DBPASS psql $DBNAME $DBUSER < schema/postgresql.sql
-export PGPASSWORD=$DBPASS psql $DBNAME $DBUSER < examples/postgresql-data.sql
+psql $DBNAME < schema/postgresql.sql
+psql $DBNAME < examples/postgresql-data.sql
 
 cat examples/anchor-token-server.conf \
 | sed -e "s/DBNAME/$DBNAME/" \
-      -e "s/DBUSER/$DBUSER/" \
-      -e "s/DBPASS/$DBPASS/" \
 > $TESTCONF
 
 # Trap the interrupt so that we can clean up.


### PR DESCRIPTION
Stop using PG user/pass so that ./runit.sh just works on my local machine.