### PR TITLE
Read TokenDetails from PostgreSQL correctly

### DIFF
--- a/lib/Anchor/Tokens/Server/Store.hs
+++ b/lib/Anchor/Tokens/Server/Store.hs
@@ -34,9 +34,10 @@ import           Control.Monad.Trans.Except
 import           Crypto.Scrypt
 import           Data.ByteString                            (ByteString)
 import qualified Data.ByteString                            as BS
-import qualified Data.ByteString.Char8                      as BC
 import qualified Data.ByteString.Base64                     as B64
+import qualified Data.ByteString.Char8                      as BC
 import           Data.Char
+import           Data.Maybe
 import           Data.Monoid
 import           Data.Pool
 import qualified Data.Set                                   as S
@@ -159,7 +160,9 @@ loadToken tok = do
     tokens :: [TokenDetails] <- withResource pool $ \conn -> do
         liftIO $ query conn "SELECT token_type, token, expires, user_id, client_id, scope FROM tokens WHERE (token = ?)" (Only tok)
     case tokens of
-        [t] -> return $ Just t
+        [t] -> do
+            liftIO $ debugM logName $ "Found a token!"
+            return $ Just t
         []  -> do
             liftIO $ debugM logName $ "No tokens found matching " <> show tok
             return Nothing
@@ -343,8 +346,9 @@ instance FromField ClientID where
     fromField f bs = do
         c <- fromField f bs
         case c ^? clientID of
-            Nothing   -> returnError ConversionFailed f ""
             Just c_id -> pure c_id
+            Nothing   -> returnError ConversionFailed f $
+                            "Failed to convert with clientID: " <> show c
 
 instance ToField ClientID where
     toField c_id = toField $ c_id ^.re clientID
@@ -356,15 +360,17 @@ instance FromField ScopeToken where
     fromField f bs = do
         x <- fromField f bs
         case x ^? scopeToken of
-            Nothing         -> returnError ConversionFailed f ""
-            Just scopeToken -> pure scopeToken
+            Just s  -> pure s
+            Nothing -> returnError ConversionFailed f $
+                           "Failed to convert with scopeToken: " <> show x
 
 instance FromField Scope where
     fromField f bs = do
-        tokenVector <- fromField f bs
-        case S.fromList (V.toList tokenVector) ^? scope of
-            Nothing    -> returnError ConversionFailed f ""
-            Just scope -> pure scope
+        (v :: V.Vector ScopeToken) <- fromField f bs
+        case S.fromList (V.toList v) ^? scope of
+            Just s  -> pure s
+            Nothing -> returnError ConversionFailed f $
+                            "Failed to convert with scope."
 
 instance ToField Token where
     toField tok = toField $ review token tok
@@ -379,17 +385,24 @@ instance ToField TokenType where
 instance FromField TokenType where
     fromField f bs
         | typeOid f /= $(inlineTypoid TI.varchar) = returnError Incompatible f ""
-        | bs == Nothing = returnError UnexpectedNull f "Token type cannot be NULL"
         | bs == bearer  = pure Bearer
         | bs == refresh = pure Refresh
-        | otherwise     = returnError ConversionFailed f $ "Unknown token type: " <> show bs
+        | bs == Nothing = returnError UnexpectedNull f $
+                              "Token type cannot be NULL."
+        | otherwise     = returnError ConversionFailed f $
+                              "Unknown token type: " <> show bs
       where
         bearer = Just "bearer"
         refresh = Just "refresh"
 
 instance ToRow TokenGrant where
-    toRow (TokenGrant ty ex uid cid sc) =
-        toRow (ty, ex, review username <$> uid, review clientID <$> cid, scopeToBs sc)
+    toRow (TokenGrant ty ex uid cid sc) = toRow
+        ( ty
+        , ex
+        , review username <$> uid
+        , review clientID <$> cid
+        , scopeToBs sc
+        )
 
 instance FromRow TokenDetails where
     fromRow = TokenDetails <$> field
@@ -397,7 +410,7 @@ instance FromRow TokenDetails where
                            <*> field
                            <*> (preview username <$> field)
                            <*> (preview clientID <$> field)
-                           <*> mebbeField bsToScope
+                           <*> field
 
 instance FromField URI where
     fromField f bs = do
@@ -425,8 +438,9 @@ instance FromField Code where
     fromField f bs = do
         x <- fromField f bs
         case x ^? code of
-            Nothing    -> returnError ConversionFailed f ""
-            Just c -> pure c
+            Just c  -> pure c
+            Nothing -> returnError ConversionFailed f $
+                           "Failed to convert with code: " <> show x
 
 instance ToField Code where
     toField x = toField $ x ^.re code


### PR DESCRIPTION
Slightly improve the PostgreSQL un-marshalling instances and, in particular, make the `FromRow TokenDetails` instance actually work.

With this in, the tests branch can actually verify a token (from a canned database).